### PR TITLE
Fix JSON-LD schema double-quoting in structured data

### DIFF
--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -1,146 +1,91 @@
 {{- if .IsPage -}}
 {{- if eq .Section "posts" -}}
 <!-- Article Schema -->
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "BlogPosting",
-  "headline": {{ .Title | jsonify }},
-  "description": {{ .Description | jsonify }},
-  "image": {
-    "@type": "ImageObject",
-    {{- if .Params.thumbnail -}}
-    "url": {{ (printf "%s%s" .Site.BaseURL .Params.thumbnail) | jsonify }},
-    {{- else if .Params.images -}}
-    "url": {{ (printf "%s%s" .Site.BaseURL (index .Params.images 0)) | jsonify }},
-    {{- else -}}
-    "url": {{ (printf "%s%s" .Site.BaseURL .Site.Params.images) | jsonify }},
-    {{- end -}}
-    "width": 1200,
-    "height": 630
-  },
-  "url": {{ .Permalink | jsonify }},
-  "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
-  "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
-  "author": {
-    "@type": "Person",
-    "name": {{ .Site.Params.author | jsonify }},
-    "url": {{ .Site.BaseURL | jsonify }},
-    "sameAs": [
-      {{- $social := slice -}}
-      {{- range .Site.Params.socialIcons -}}
-        {{- if ne .title "e-mail" -}}
-          {{- $social = $social | append .url -}}
-        {{- end -}}
-      {{- end -}}
-      {{- range $i, $url := $social -}}
-        {{- if $i -}},{{- end -}}
-        {{ $url | jsonify }}
-      {{- end -}}
-    ]
-  },
-  "publisher": {
-    "@type": "Person",
-    "name": {{ .Site.Params.author | jsonify }},
-    "url": {{ .Site.BaseURL | jsonify }},
-    "logo": {
-      "@type": "ImageObject",
-      "url": {{ (printf "%s%s" .Site.BaseURL .Site.Params.profilePicture) | jsonify }},
-      "width": 200,
-      "height": 200
-    }
-  },
-  "mainEntityOfPage": {
-    "@type": "WebPage",
-    "@id": {{ .Permalink | jsonify }}
-  },
-  {{- if .Params.tags -}}
-  "keywords": [
-    {{- range $i, $tag := .Params.tags -}}
-      {{- if $i -}},{{- end -}}
-      {{ $tag | jsonify }}
-    {{- end -}}
-  ],
+{{- $social := slice -}}
+{{- range .Site.Params.socialIcons -}}
+  {{- if ne .title "e-mail" -}}
+    {{- $social = $social | append .url -}}
   {{- end -}}
-  "articleSection": "{{ .Section | title }}",
-  "wordCount": {{ .WordCount }},
-  "inLanguage": "{{ .Site.Language.Lang }}"
-}
+{{- end -}}
+{{- $image := "" -}}
+{{- if .Params.thumbnail -}}
+  {{- $image = printf "%s%s" .Site.BaseURL .Params.thumbnail -}}
+{{- else if .Params.images -}}
+  {{- $image = printf "%s%s" .Site.BaseURL (index .Params.images 0) -}}
+{{- else -}}
+  {{- $image = printf "%s%s" .Site.BaseURL .Site.Params.images -}}
+{{- end -}}
+{{- $schema := dict
+  "@context" "https://schema.org"
+  "@type" "BlogPosting"
+  "headline" .Title
+  "description" .Description
+  "image" (dict "@type" "ImageObject" "url" $image "width" 1200 "height" 630)
+  "url" .Permalink
+  "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
+  "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+  "author" (dict "@type" "Person" "name" .Site.Params.author "url" .Site.BaseURL "sameAs" $social)
+  "publisher" (dict "@type" "Person" "name" .Site.Params.author "url" .Site.BaseURL "logo" (dict "@type" "ImageObject" "url" (printf "%s%s" .Site.BaseURL .Site.Params.profilePicture) "width" 200 "height" 200))
+  "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)
+  "articleSection" (.Section | title)
+  "wordCount" .WordCount
+  "inLanguage" .Site.Language.Lang
+-}}
+{{- if .Params.tags -}}
+  {{- $schema = merge $schema (dict "keywords" .Params.tags) -}}
+{{- end -}}
+<script type="application/ld+json">
+{{ $schema | jsonify | safeJS }}
 </script>
 {{- end -}}
 {{- end -}}
 
 {{- if .IsHome -}}
 <!-- Website Schema -->
+{{- $social := slice -}}
+{{- range .Site.Params.socialIcons -}}
+  {{- if ne .title "e-mail" -}}
+    {{- $social = $social | append .url -}}
+  {{- end -}}
+{{- end -}}
+{{- $schema := dict
+  "@context" "https://schema.org"
+  "@type" "WebSite"
+  "name" .Site.Title
+  "description" .Site.Params.description
+  "url" .Site.BaseURL
+  "author" (dict
+    "@type" "Person"
+    "name" .Site.Params.author
+    "url" .Site.BaseURL
+    "jobTitle" "Cloud Native Specialist"
+    "worksFor" (dict "@type" "Organization" "name" "12F APS" "url" "https://12f.dk")
+    "sameAs" $social
+  )
+  "potentialAction" (dict
+    "@type" "SearchAction"
+    "target" (printf "%ssearch?q={search_term_string}" .Site.BaseURL)
+    "query-input" "required name=search_term_string"
+  )
+-}}
 <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  "name": {{ .Site.Title | jsonify }},
-  "description": {{ .Site.Params.description | jsonify }},
-  "url": {{ .Site.BaseURL | jsonify }},
-  "author": {
-    "@type": "Person",
-    "name": {{ .Site.Params.author | jsonify }},
-    "url": {{ .Site.BaseURL | jsonify }},
-    "jobTitle": "Cloud Native Specialist",
-    "worksFor": {
-      "@type": "Organization",
-      "name": "12F APS",
-      "url": "https://12f.dk"
-    },
-    "sameAs": [
-      {{- $social := slice -}}
-      {{- range .Site.Params.socialIcons -}}
-        {{- if ne .title "e-mail" -}}
-          {{- $social = $social | append .url -}}
-        {{- end -}}
-      {{- end -}}
-      {{- range $i, $url := $social -}}
-        {{- if $i -}},{{- end -}}
-        {{ $url | jsonify }}
-      {{- end -}}
-    ]
-  },
-  "potentialAction": {
-    "@type": "SearchAction",
-    "target": "{{ .Site.BaseURL }}search?q={search_term_string}",
-    "query-input": "required name=search_term_string"
-  }
-}
+{{ $schema | jsonify | safeJS }}
 </script>
 {{- end -}}
 
 <!-- Breadcrumb Schema -->
 {{- if not .IsHome -}}
+{{- $items := slice (dict "@type" "ListItem" "position" 1 "name" "Home" "item" .Site.BaseURL) -}}
+{{- if .Section -}}
+  {{- $items = $items | append (dict "@type" "ListItem" "position" 2 "name" (.Section | title) "item" (printf "%s%s/" .Site.BaseURL .Section)) -}}
+{{- end -}}
+{{- if .IsPage -}}
+  {{- $pos := 2 -}}
+  {{- if .Section -}}{{- $pos = 3 -}}{{- end -}}
+  {{- $items = $items | append (dict "@type" "ListItem" "position" $pos "name" .Title "item" .Permalink) -}}
+{{- end -}}
+{{- $schema := dict "@context" "https://schema.org" "@type" "BreadcrumbList" "itemListElement" $items -}}
 <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": {{ .Site.BaseURL | jsonify }}
-    }
-    {{- if .Section -}},
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": {{ .Section | title | jsonify }},
-      "item": {{ printf "%s%s/" .Site.BaseURL .Section | jsonify }}
-    }
-    {{- end -}}
-    {{- if .IsPage -}},
-    {
-      "@type": "ListItem",
-      "position": {{ if .Section }}3{{ else }}2{{ end }},
-      "name": {{ .Title | jsonify }},
-      "item": {{ .Permalink | jsonify }}
-    }
-    {{- end -}}
-  ]
-}
+{{ $schema | jsonify | safeJS }}
 </script>
 {{- end -}}


### PR DESCRIPTION
## Summary
- Rewrites `schema.html` to use Hugo `dict` + `jsonify` instead of manual JSON templates
- Eliminates double-quoted values like `"\"Robert-Jensen.dk\""` → `"Robert-Jensen.dk"`
- Uses `safeJS` to prevent Hugo from re-escaping the JSON output
- All three schema types fixed: BlogPosting, WebSite, BreadcrumbList

## Test plan
- [x] Homepage JSON-LD validates with correct values
- [x] Blog post JSON-LD validates with correct values
- [x] Breadcrumb schema renders correctly
- [x] No escaped quotes in any values

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)