### PR TITLE
fix(seo): remove double slash in publisher logo URL (#53)

### DIFF
--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -25,7 +25,7 @@
   "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
   "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
   "author" (dict "@type" "Person" "name" .Site.Params.author "url" .Site.BaseURL "sameAs" $social)
-  "publisher" (dict "@type" "Person" "name" .Site.Params.author "url" .Site.BaseURL "logo" (dict "@type" "ImageObject" "url" (printf "%s%s" .Site.BaseURL .Site.Params.profilePicture) "width" 200 "height" 200))
+  "publisher" (dict "@type" "Person" "name" .Site.Params.author "url" .Site.BaseURL "logo" (dict "@type" "ImageObject" "url" (.Site.Params.profilePicture | absURL) "width" 200 "height" 200))
   "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)
   "articleSection" (.Section | title)
   "wordCount" .WordCount


### PR DESCRIPTION
## Issue
Closes #53

## Problem
`BlogPosting` → `publisher.logo.url` was assembled with `printf "%s%s" .Site.BaseURL .Site.Params.profilePicture`, joining a trailing-slash baseURL with a leading-slash path → `https://www.robert-jensen.dk//images/profile.webp`.

## Fix
Use `.Site.Params.profilePicture | absURL`, which joins the path to the baseURL correctly regardless of slashes.

## Verification
Built with the `www` baseURL; the Talos post's JSON-LD now emits:
`"url":"https://www.robert-jensen.dk/images/profile.webp"` (single slash, verified no `dk//images`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)