### PR TITLE
fix(seo): brand as title suffix; keyword-rich homepage title (#48)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,19 +1,17 @@
 <head>
   <meta charset="utf-8" />
+  {{/* Title: brand as SUFFIX on interior pages (SEO issue #48); keyword-rich
+       title on the homepage. Set params.homeTitle to override the home title. */}}
   <title>
-    {{ if (eq .Site.Params.reversepagetitle true) }}
-      {{ with .Title }}
-        {{ . }} |
-      {{ end }}
-      {{- .Site.Params.author -}}
-    {{ else }}
-      {{- .Site.Params.author -}}{{ with .Title }}
-        |
-        {{ . }}
-      {{ end }}
-
-    {{ end }}
-
+    {{- if .IsHome -}}
+      {{ or .Site.Params.homeTitle (printf "%s — Cloud Native, Kubernetes & DevOps" .Site.Title) }}
+    {{- else -}}
+      {{- with .Title -}}
+        {{ . }} · {{ $.Site.Title }}
+      {{- else -}}
+        {{ $.Site.Title }}
+      {{- end -}}
+    {{- end -}}
   </title>
 
   <!-- Meta -->


### PR DESCRIPTION
## Issue
Closes #48

## Problem
Every page rendered `<title>` as `Robert Jensen [Title]` — brand as a **prefix**, with a literal newline inside the tag. The homepage title was `Robert Jensen Robert-Jensen.dk` (no topic keywords).

## Fix
Rewrote the title block in `layouts/partials/head.html`:
- **Interior pages:** `{{ .Title }} · Robert-Jensen.dk` (brand as suffix)
- **Homepage:** `Robert-Jensen.dk — Cloud Native, Kubernetes & DevOps` (overridable via `params.homeTitle`)
- Single-line output, no stray newline

## Verification
Built with the `www` baseURL:
| Page | Title |
|---|---|
| Home | `Robert-Jensen.dk — Cloud Native, Kubernetes & DevOps` |
| Post | `Fix LoadBalancer Services… · Robert-Jensen.dk` |
| About | `About · Robert-Jensen.dk` |
| Tag list | `Kubernetes · Robert-Jensen.dk` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)