### PR TITLE
fix(seo): unique meta descriptions for homepage & section pages (#50)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Robert-Jensen.dk"
+description: "Robert Jensen's blog on cloud native development, Kubernetes, Docker, DevOps automation and VMware/Tanzu — hands-on homelab guides, tutorials and field notes."
+---

--- a/content/events/index.md
+++ b/content/events/index.md
@@ -4,6 +4,7 @@ date: 2023-01-17T11:56:57+01:00
 relatedPosts: false
 #draft: true
 thumbnail: "images/events.webp"
+description: "Talks and speaking engagements by Robert Jensen on cloud native, Kubernetes, Tanzu Application Platform, Backstage and DevOps — with slides and recordings."
 ---
 ## 2024
 

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Posts"
+description: "All posts from Robert-Jensen.dk — tutorials and troubleshooting on Kubernetes, Docker, Traefik, VMware/Tanzu, CI/CD and homelab automation."
+---

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,14 +18,19 @@
   {{- hugo.Generator -}}
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
   <meta name="author" content="{{ .Site.Params.author }}" />
-  <meta
-    name="description"
-    content="{{ if .Params.description }}
-      {{- .Params.description -}}
-    {{ else }}
-      {{- .Site.Params.description -}}
-    {{ end }}"
-  />
+  {{/* Meta description: explicit front-matter description wins; taxonomy term
+       pages get an auto-generated one; otherwise fall back to site desc (#50). */}}
+  {{- $desc := .Site.Params.description -}}
+  {{- with .Params.description -}}
+    {{- $desc = . -}}
+  {{- else -}}
+    {{- if eq .Kind "term" -}}
+      {{- $desc = printf "Posts tagged “%s” on %s — cloud native, Kubernetes, DevOps and homelab notes." .Title .Site.Title -}}
+    {{- else if eq .Kind "taxonomy" -}}
+      {{- $desc = printf "Browse posts by %s on %s." (.Title | lower) .Site.Title -}}
+    {{- end -}}
+  {{- end -}}
+  <meta name="description" content="{{ $desc | plainify | chomp }}" />
   {{ if .Params.redirectUrl }}
     <meta http-equiv="refresh" content="1; url={{ .Params.redirectUrl }}" />
   {{ end }}


### PR DESCRIPTION
## Issue
Closes #50

## Problem
The homepage, `/posts/` and `/events/` all emitted the generic site tagline ("A place for my random ramblings…") as their meta description. Taxonomy/tag pages did too.

## Fix
- Add explicit `description` front matter for the homepage (`content/_index.md`), the posts section (`content/posts/_index.md`) and events.
- Auto-generate descriptions for taxonomy `term`/`taxonomy` pages in `head.html`.
- Existing per-post descriptions are untouched.

`_index.md` files are front-matter-only; `index.html` and `list.html` build from page lists and don't render `.Content`, so the homepage hero and list layouts are unchanged (verified).

## Verification (built with www baseURL)
| Page | Description |
|---|---|
| Home | Robert Jensen's blog on cloud native development, Kubernetes, Docker… |
| /posts/ | All posts from Robert-Jensen.dk — tutorials and troubleshooting… |
| /events/ | Talks and speaking engagements by Robert Jensen… |
| /tags/kubernetes/ | Posts tagged "Kubernetes" on Robert-Jensen.dk… (auto) |
| Post | (unchanged — uses its own description) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)