### PR TITLE
fix(seo,a11y): replace boilerplate thumbnail alt text (#54)

### DIFF
--- a/content/posts/2026-building-home-stories-app/index.md
+++ b/content/posts/2026-building-home-stories-app/index.md
@@ -6,6 +6,7 @@ description: "The honest story behind Home Stories, an iOS app for homeowners to
 tags: ["ios", "side-project", "home-renovation"]
 toc: true
 thumbnail: "images/home-stories-hero.webp"
+thumbnailAlt: "The Home Stories iOS app shown on a phone, displaying a home renovation project with budget tracking"
 images: ["images/home-stories-hero.webp"]
 categories: ["Projects"]
 ---

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,10 +10,12 @@
     
     {{ if .Params.thumbnail }}
       <div class="post__thumbnail-wrapper">
+        {{/* Descriptive alt from params.thumbnailAlt; otherwise the hero is
+             decorative (title H1 sits beside it) → empty alt, not boilerplate (#54). */}}
         <img
           class="post__thumbnail"
           src="{{ .Params.thumbnail | relURL }}"
-          alt="Thumbnail for {{ .Title }}"
+          alt="{{ .Params.thumbnailAlt }}"
           width="600"
           height="338"
           loading="eager"

--- a/layouts/partials/post-visual.html
+++ b/layouts/partials/post-visual.html
@@ -6,7 +6,7 @@
     <img
       class="pv__img"
       src="{{ . | relURL }}"
-      alt="{{ $page.Title }}"
+      alt="{{ $page.Params.thumbnailAlt }}"
       width="600"
       height="338"
       loading="{{ if $eager }}eager{{ else }}lazy{{ end }}"


### PR DESCRIPTION
## Issue
Closes #54

## Problem
Post hero thumbnails used `alt="Thumbnail for {{ .Title }}"` (single.html) and the raw title (post-visual.html) — boilerplate that duplicates the visible title for screen-reader users.

## Fix
- Honor an optional `params.thumbnailAlt` for a genuinely descriptive alt.
- When absent, the hero is treated as **decorative** with empty `alt=""` (WCAG-correct next to the title H1) instead of boilerplate.
- Added a descriptive `thumbnailAlt` to the Home Stories post as a demonstration.

## Verification (built with www baseURL)
- No `Thumbnail for` string remains anywhere in the built site.
- Home Stories: `alt="The Home Stories iOS app shown on a phone…"`.
- Talos post (no thumbnailAlt): decorative empty alt.

Authors can add `thumbnailAlt: "…"` to any post's front matter to give its hero a descriptive alt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)