### PR TITLE
feat(seo): front-matter-driven HowTo & FAQ schema for tutorials (#47)

### DIFF
--- a/content/posts/2025-loadbalancer-not-working-on-single-node-talos-cluster/index.md
+++ b/content/posts/2025-loadbalancer-not-working-on-single-node-talos-cluster/index.md
@@ -7,6 +7,25 @@ toc: true
 thumbnail: "images/jackson-simmer-Vqg809B-SrE-unsplash.webp"
 images: ["images/jackson-simmer-Vqg809B-SrE-unsplash.webp"]
 description: "Step-by-step guide to fixing LoadBalancer services on single-node Talos Kubernetes clusters by modifying node labels for both Cilium and MetalLB implementations."
+howto:
+  name: "Fix LoadBalancer services on a single-node Talos Kubernetes cluster"
+  description: "Remove the control-plane label that excludes a single-node Talos cluster from external load balancing, so LoadBalancer services work with Cilium and MetalLB."
+  steps:
+    - name: "Identify the blocking node label"
+      text: "Talos adds node.kubernetes.io/exclude-from-external-load-balancers to control-plane nodes. On a single-node cluster the control-plane node is also the only worker, so this label stops LoadBalancer services from being exposed."
+    - name: "Comment out the nodeLabels block in the machine config"
+      text: "In your control-plane machine configuration, comment out the machine.nodeLabels block that sets node.kubernetes.io/exclude-from-external-load-balancers."
+    - name: "Apply the updated configuration"
+      text: "Apply the updated machine configuration. On an already-running cluster this removes the label from the node."
+    - name: "Verify LoadBalancer services"
+      text: "After applying, LoadBalancer services keep their assigned external IP and become reachable, for both Cilium and MetalLB."
+faq:
+  - q: "Why don't LoadBalancer services work on a single-node Talos cluster?"
+    a: "Talos labels control-plane nodes with node.kubernetes.io/exclude-from-external-load-balancers. On a single-node cluster the control-plane node is also the only worker, so this label prevents LoadBalancer services from being exposed even though they get an external IP."
+  - q: "Does this affect both Cilium and MetalLB?"
+    a: "Yes. The same control-plane label blocks external load balancing regardless of whether you use Cilium or MetalLB."
+  - q: "How do I fix LoadBalancer services on a single-node Talos cluster?"
+    a: "Comment out the machine.nodeLabels block containing node.kubernetes.io/exclude-from-external-load-balancers in the control-plane machine configuration and apply the updated config."
 ---
 ## Intro
 

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -37,6 +37,40 @@
 <script type="application/ld+json">
 {{ $schema | jsonify | safeJS }}
 </script>
+{{/* HowTo schema (opt-in via front-matter `howto`) — for step-by-step
+     tutorials. See CLAUDE.md / any tutorial post for the shape (#47). */}}
+{{- with .Params.howto -}}
+  {{- $steps := slice -}}
+  {{- range $i, $s := .steps -}}
+    {{- $steps = $steps | append (dict "@type" "HowToStep" "position" (add $i 1) "name" $s.name "text" $s.text) -}}
+  {{- end -}}
+  {{- $howto := dict
+    "@context" "https://schema.org"
+    "@type" "HowTo"
+    "name" (or .name $.Title)
+    "step" $steps
+  -}}
+  {{- with .description -}}{{ $howto = merge $howto (dict "description" .) }}{{- end -}}
+  {{- with .totalTime -}}{{ $howto = merge $howto (dict "totalTime" .) }}{{- end -}}
+<script type="application/ld+json">
+{{ $howto | jsonify | safeJS }}
+</script>
+{{- end -}}
+{{/* FAQPage schema (opt-in via front-matter `faq`: list of {q, a}) (#47). */}}
+{{- with .Params.faq -}}
+  {{- $questions := slice -}}
+  {{- range . -}}
+    {{- $questions = $questions | append (dict "@type" "Question" "name" .q "acceptedAnswer" (dict "@type" "Answer" "text" .a)) -}}
+  {{- end -}}
+  {{- $faq := dict
+    "@context" "https://schema.org"
+    "@type" "FAQPage"
+    "mainEntity" $questions
+  -}}
+<script type="application/ld+json">
+{{ $faq | jsonify | safeJS }}
+</script>
+{{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## Issue
Closes #47 (🔴 critical — AEO)

## Problem
Step-by-step tutorials carried only `BlogPosting` markup — no `HowTo` or `FAQPage` — forfeiting rich results and AI-answer citations.

## Fix
Added an opt-in, front-matter-driven mechanism in `layouts/partials/schema.html`:

```yaml
howto:
  name: "..."          # optional; defaults to the post title
  description: "..."    # optional
  totalTime: "PT5M"     # optional (ISO 8601)
  steps:
    - name: "..."
      text: "..."
faq:
  - q: "..."
    a: "..."
```

- `howto` → `HowTo` JSON-LD with ordered `HowToStep`s.
- `faq` → `FAQPage` JSON-LD with `Question`/`acceptedAnswer`.

Applied to the **single-node Talos LoadBalancer** post as the first worked example (content-accurate: 4 steps, 3 FAQs). Remaining tutorials opt in by adding the same front matter — no template changes needed.

## Verification (built with www baseURL)
- Talos post now emits 4 valid JSON-LD blocks: `BlogPosting`, `HowTo` (4 steps), `FAQPage` (3 Q&A), `BreadcrumbList` — all parse as valid JSON.
- A post without the front matter (external-dns) emits **no** HowTo/FAQPage (no regression).

Recommend validating the live post in Google's Rich Results Test after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)