### PR TITLE
feat(seo): opt-in Speakable schema for voice search (#56)

### DIFF
--- a/content/posts/2025-loadbalancer-not-working-on-single-node-talos-cluster/index.md
+++ b/content/posts/2025-loadbalancer-not-working-on-single-node-talos-cluster/index.md
@@ -7,6 +7,7 @@ toc: true
 thumbnail: "images/jackson-simmer-Vqg809B-SrE-unsplash.webp"
 images: ["images/jackson-simmer-Vqg809B-SrE-unsplash.webp"]
 description: "Step-by-step guide to fixing LoadBalancer services on single-node Talos Kubernetes clusters by modifying node labels for both Cilium and MetalLB implementations."
+speakable: true
 howto:
   name: "Fix LoadBalancer services on a single-node Talos Kubernetes cluster"
   description: "Remove the control-plane label that excludes a single-node Talos cluster from external load balancing, so LoadBalancer services work with Cilium and MetalLB."

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -34,6 +34,13 @@
 {{- if .Params.tags -}}
   {{- $schema = merge $schema (dict "keywords" .Params.tags) -}}
 {{- end -}}
+{{/* Speakable (opt-in via front-matter `speakable: true`) marks the
+     voice-friendly summary section; override selectors with
+     `speakableSelectors: [ ... ]` (#56). */}}
+{{- if .Params.speakable -}}
+  {{- $sel := or .Params.speakableSelectors (slice ".post__content h1" ".post__content > p:first-of-type") -}}
+  {{- $schema = merge $schema (dict "speakable" (dict "@type" "SpeakableSpecification" "cssSelector" $sel)) -}}
+{{- end -}}
 <script type="application/ld+json">
 {{ $schema | jsonify | safeJS }}
 </script>


### PR DESCRIPTION
## Issue
Closes #56 (AEO)

## Fix
When a post sets `speakable: true`, `BlogPosting` now includes a `SpeakableSpecification` pointing at the headline and first paragraph (the voice-friendly summary). Selectors are overridable via `speakableSelectors: [ ... ]`. Enabled on the Talos post; complements the HowTo/FAQ work in #47.

## Verification (built with www baseURL)
- Talos BlogPosting includes valid `speakable` → `SpeakableSpecification` with `cssSelector [".post__content h1", ".post__content > p:first-of-type"]`.
- Posts without `speakable` emit none (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)