### PR TITLE
content(seo): question-phrased headings + direct answers in tutorials (#49)

### DIFF
--- a/content/posts/2024-fixing-cilium-with-kind/index.md
+++ b/content/posts/2024-fixing-cilium-with-kind/index.md
@@ -24,7 +24,9 @@ For me, Docker Desktop is gone, and I will test out Colima in my env going forwa
 I have started playing with [Cilium](https://cilium.io), and learning about all the interesting things it offeres. 
 That involves running a local Kind cluster, where I can quickly test things out. 
 
-## Problem
+**Short answer:** On an Apple Silicon (M1) Mac, Cilium's DaemonSet pods keep restarting and CoreDNS never starts on a Kind cluster running under Docker Desktop. Replacing Docker Desktop with [Colima](https://github.com/abiosoft/colima) (or downgrading the Docker engine) fixes it, and the Cilium Kind guide then works normally.
+
+## Why does Cilium fail on a Kind cluster on an M1 Mac?
 
 Cilium has a [guide](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/) on how to run this on a Kind cluster. The only problem, is that it's not working on my M1 Macbook.
 
@@ -34,7 +36,7 @@ This means it's pretty useless for me.
 
 I have created a [PR](https://github.com/cilium/cilium/issues/30278), where I think the error was found, but no real solution, until [Parshin Pavel](https://github.com/pparshin) gave me a workaround.
 
-## Solution
+## How to fix Cilium on Kind (M1 Mac): replace Docker Desktop with Colima
 
 The workaround was simply to replace Docker desktop with [Colima](https://github.com/abiosoft/colima)
 

--- a/content/posts/2024-vcf-create-transport-node-collection-fails/index.md
+++ b/content/posts/2024-vcf-create-transport-node-collection-fails/index.md
@@ -10,7 +10,9 @@ images: ["images/tim-mossholder-rx_GNopVlFs-unsplash.webp"]
 description: "Troubleshooting guide for VMware Cloud Foundation (VCF) deployment failure during Transport Node Collection creation at 48%. Learn how to resolve NSX Manager connectivity issues and firewall configuration problems in your VMware infrastructure."
 slug: "vmware-vcf-create-transport-node-collection-fails"
 ---
-## The problem
+**Short answer:** If VCF Cloud Builder fails at "Create Transport Node Collection" (around 48%) with the ESXi hosts stuck on "Waiting for connection to managers", a firewall between the ESXi hosts and the NSX managers is silently dropping the traffic on port 1234. Setting the firewall rule to allow the traffic (any/any, instead of application-aware filtering) resolves it.
+
+## Why does VCF fail at 48% on "Create Transport Node Collection"?
 
 For a clean installation, Cloud Builder fails with the step "Create Transport Node Collection".
 
@@ -43,7 +45,7 @@ A VMware support engineer (Danilo) helped me, and solved the problem.
 
 He found that there was a firewall dropping the connection, after doing a packet trace.
 
-## Solution
+## How to fix it: allow the traffic through the firewall
 
 Going back to my network engineer, we found out, that he had set the firewall to allow all application trafic. 
 

--- a/content/posts/2025-loadbalancer-not-working-on-single-node-talos-cluster/index.md
+++ b/content/posts/2025-loadbalancer-not-working-on-single-node-talos-cluster/index.md
@@ -34,7 +34,9 @@ I've started playing around with [Talos](https://www.talos.dev) for my homelab s
 
 In my lab, I only have a single Intel NUC that needs to function as both control plane (master) and worker node. This should work fine in theory, but after setting everything up, I ran into an issue with LoadBalancer services.
 
-## The Problem
+**Short answer:** Talos adds the label `node.kubernetes.io/exclude-from-external-load-balancers` to control-plane nodes. On a single-node cluster that node is also your only worker, so the label stops LoadBalancer services from being exposed (with both Cilium and MetalLB). Comment out that `nodeLabels` block in the machine config and re-apply, and LoadBalancer services start working.
+
+## Why don't LoadBalancer services work on a single-node Talos cluster?
 
 I tried setting up LoadBalancer services using both [Cilium](https://cilium.io) and [MetalLB](https://metallb.universe.tf), but encountered the same problem with both solutions.
 
@@ -47,7 +49,7 @@ When I tried accessing the service directly using port-forwarding (`kubectl port
 
 I went through multiple reinstallations and troubleshooting attempts, but nothing seemed to solve the issue.
 
-## Solution
+## How do I fix LoadBalancer services on a single-node Talos cluster?
 
 After digging through various GitHub issues, I finally found the solution in this MetalLB issue: [https://github.com/metallb/metallb/issues/2676](https://github.com/metallb/metallb/issues/2676)
 


### PR DESCRIPTION
## Issue
Closes #49 (AEO)

## Change
For the clearest troubleshooting tutorials, rephrased the generic `Problem`/`Solution` H2s into natural questions and added a concise **Short answer** paragraph near the top (featured-snippet / voice best practice):

- **Talos single-node LoadBalancer** — "Why don't LoadBalancer services work…" / "How do I fix…"
- **Cilium on Kind (M1 Mac)** — "Why does Cilium fail on a Kind cluster on an M1 Mac?" / "How to fix… replace Docker Desktop with Colima"
- **VCF Create Transport Node Collection** — "Why does VCF fail at 48%…" / "How to fix it: allow the traffic through the firewall"

Author's casual voice preserved; opinion/narrative posts were intentionally **not** given question headings. The same pattern can be applied to further tutorials over time.

## Verification
Built with the www baseURL; all six headings render as questions and each post carries one `Short answer` lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)