### PR TITLE
content(seo): noindex thin posts; signal freshness via lastmod (#51)

### DIFF
--- a/content/posts/2018-cloud-managent-experience-day/index.md
+++ b/content/posts/2018-cloud-managent-experience-day/index.md
@@ -7,6 +7,7 @@ images: ["images/clay-banks-LjqARJaJotc-unsplash.webp"]
 draft: false
 aliases: [ "/2018/02/cloud-managent-experience-day.html" ]
 tags: [vmware, automation, cloud]
+noindex: true
 ---
 
 [![Cloud Management Experience Day learning event banner](https://static-1.europeanschooluxembourg2.eu/wp-content/uploads/education_button2.jpg)](https://static-1.europeanschooluxembourg2.eu/wp-content/uploads/education_button2.jpg)

--- a/content/posts/2020-move-blog/index.md
+++ b/content/posts/2020-move-blog/index.md
@@ -7,6 +7,7 @@ tags: [homelab]
 thumbnail: "images/erda-estremera-sxNt9g77PE0-unsplash.webp"
 images: ["images/erda-estremera-sxNt9g77PE0-unsplash.webp"]
 #draft: true
+noindex: true
 ---
 For the last year or so, I have seen a lot of people, talking about their move of blogs, from a traditionel CMS system, to a static site.
 

--- a/content/posts/2021-new-role/index.md
+++ b/content/posts/2021-new-role/index.md
@@ -8,6 +8,7 @@ images: ["images/jack-sloop-eYwn81sPkJ8-unsplash.webp"]
 description: "Transitioning from VMware Cloud Management Specialist to Modern Applications business unit, focusing on Tanzu platform and DevOps practices for developers."
 #images: 
 #- "images/ross-findon-mG28olYFgHI-unsplash.jpg"
+noindex: true
 ---
 For the last +4 years, I have had the role, of [Cloud Management Specialist](/posts/2019/vmware-cloud-management-series/) @ VMware.
 

--- a/content/posts/2024-fixing-cilium-with-kind/index.md
+++ b/content/posts/2024-fixing-cilium-with-kind/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Fixing Cilium on Kind"
 date: 2024-01-25T12:00:00+01:00
+lastmod: 2026-07-16T12:00:00+02:00
 tags: [kubernetes, networking, docker]
 draft: false
 toc: true

--- a/content/posts/2024-vcf-create-transport-node-collection-fails/index.md
+++ b/content/posts/2024-vcf-create-transport-node-collection-fails/index.md
@@ -1,6 +1,7 @@
 ---
 title: "VCF Create Transport Node Collection fails at 48 percent"
 date: 2024-08-29T12:00:00+01:00
+lastmod: 2026-07-16T12:00:00+02:00
 tags: [vmware, networking]
 draft: false
 toc: true

--- a/content/posts/2025-loadbalancer-not-working-on-single-node-talos-cluster/index.md
+++ b/content/posts/2025-loadbalancer-not-working-on-single-node-talos-cluster/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Fix LoadBalancer Services Not Working on Single Node Talos Kubernetes Cluster"
 date: 2025-03-26T12:00:00+01:00
+lastmod: 2026-07-16T12:00:00+02:00
 tags: [kubernetes, homelab, networking]
 draft: false
 toc: true

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,6 +31,10 @@
     {{- end -}}
   {{- end -}}
   <meta name="description" content="{{ $desc | plainify | chomp }}" />
+  {{/* Per-page noindex for thin/obsolete content (#51). Links still followed. */}}
+  {{- if .Params.noindex }}
+    <meta name="robots" content="noindex,follow" />
+  {{- end }}
   {{ if .Params.redirectUrl }}
     <meta http-equiv="refresh" content="1; url={{ .Params.redirectUrl }}" />
   {{ end }}


### PR DESCRIPTION
## Issue
Closes #51 (SEO/GEO)

## Change
Two parts:

**1. Thin/obsolete content → noindex**
- Added per-page `noindex` front-matter support in `head.html` (`<meta name="robots" content="noindex,follow">` — links still followed, so equity flows).
- Applied `noindex: true` to three genuinely thin, dated posts with no search value and stale/dead links:
  - `new-role` (169 words, 2021 career note with a dead job link)
  - `move-blog` (282 words, describes a Netlify setup the site no longer uses)
  - `cloud-management-experience-day` (a long-past Feb-2018 event with dead links)

These stay reachable via direct link/RSS; they're just removed from search. I chose noindex over fabricating personal prose.

**2. Freshness signal → lastmod**
Added a truthful `lastmod: 2026-07-16` to the three tutorials actually revised in this SEO pass (Talos, Cilium-on-Kind, VCF), so `dateModified` now post-dates `datePublished`. Authors set `lastmod:` on any future real revision.

## Verification (built with www baseURL)
- The three thin posts emit `robots: noindex,follow`; a normal post (Talos) stays indexable.
- Revised posts show `dateModified 2026-07-16` > their original `datePublished`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)